### PR TITLE
feat: Refactor bump command and add tag pushing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,34 @@ Before you can use Bump, you need to ensure that you have a Go environment set u
 After you have successfully built the `version-bumper`, you can use it by running the executable followed by the specific version bump you want to apply.
 
 ```sh
-./bump patch              # Bump the patch version
-./bump minor              # Bump the minor version
-./bump major --suffix rc1 # Bump the major version (all commands support optional --suffix flag)
+./bump patch              # Bump the patch version (creates tag, does not push)
+./bump patch --push       # Bump the patch version and push the tag to remote
+./bump minor              # Bump the minor version (creates tag, does not push)
+./bump minor --push       # Bump the minor version and push the tag to remote
+./bump major --suffix rc1 # Bump the major version with a suffix (creates tag, does not push)
+./bump major --suffix rc1 --push # Bump the major version with a suffix and push the tag
+./bump push               # Push all tags to remote (can be run separately)
 ```
+
+If you do not specify the `--push` flag, the tool will print the command you should run to push the tag manually (e.g., `git push --tags`).
+
+## Per-Repository Default Push Preference
+
+You can set a default for whether tags are pushed after bumping, on a per-repo basis. This is stored in your repo's `.git/config`.
+
+To set the default to push after bumping:
+
+```sh
+./bump config --default-push
+```
+
+To set the default to NOT push after bumping:
+
+```sh
+./bump config --default-push=false
+```
+
+If you do not specify `--push` on the command line, the tool will use the repo default. If neither is set, it will not push by default.
 
 ## How It Works
 

--- a/bump_test.go
+++ b/bump_test.go
@@ -188,7 +188,6 @@ func TestParseInt(t *testing.T) {
 	}
 }
 
-
 func TestOpenGitRepoInvalidPath(t *testing.T) {
 	// Test case to ensure openGitRepo returns an error for an invalid path
 	repo, err := openGitRepo("/invalid/path")
@@ -200,7 +199,6 @@ func TestOpenGitRepoInvalidPath(t *testing.T) {
 	}
 }
 
-
 func TestCreateTag(t *testing.T) {
 	// Test case to ensure createTag returns an error for an invalid command
 	err := createTag("")
@@ -208,7 +206,6 @@ func TestCreateTag(t *testing.T) {
 		t.Errorf("Expected error for invalid tag command, got nil")
 	}
 }
-
 
 func TestCompareVersionsEqual(t *testing.T) {
 	// This test ensures compareVersions returns false for equal versions
@@ -219,7 +216,6 @@ func TestCompareVersionsEqual(t *testing.T) {
 	}
 }
 
-
 func TestNewGitInfoInvalidPath(t *testing.T) {
 	// This test ensures NewGitInfo returns an error for an invalid path
 	_, err := NewGitInfo("/invalid/path")
@@ -228,15 +224,21 @@ func TestNewGitInfoInvalidPath(t *testing.T) {
 	}
 }
 
-
-func TestTagAndPushInvalidRepoPath(t *testing.T) {
-	// This test ensures TagAndPush returns an error for an invalid repository path
-	err := TagAndPush("/invalid/path", "v1.2.3")
+func TestCreateTagInvalid(t *testing.T) {
+	// This test ensures CreateTag returns an error for an invalid tag
+	err := CreateTag("")
 	if err == nil {
-		t.Errorf("Expected error for invalid repository path, got nil")
+		t.Errorf("Expected error for invalid tag, got nil")
 	}
 }
 
+func TestPushTagInvalid(t *testing.T) {
+	// This test ensures PushTag returns an error if push fails (simulate by running outside a git repo)
+	err := PushTag()
+	if err == nil {
+		t.Errorf("Expected error for push outside a git repo, got nil")
+	}
+}
 
 func TestCompareVersionsHigherPatch(t *testing.T) {
 	// This test ensures compareVersions correctly compares versions with different patch numbers

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/log v0.4.1
 	github.com/go-git/go-git/v5 v5.13.0
 	github.com/urfave/cli/v2 v2.27.5
+	gopkg.in/ini.v1 v1.67.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
add features for pushing as an option and configuring defaults


- Modify test case for `TestCreateTag` to check for invalid tag command error
- Add new test case `TestCreateTagInvalid` to check for invalid tag error
- Add version `v1.67.0` of `gopkg.in/ini.v1` to `go.sum`
- Add requirement for `gopkg.in/ini.v1 v1.67.0` in `go.mod`
- Add new "push" command to push tags to remote in `cmd/bump/main.go`
- Add new "config" command to configure bump settings for repo in `cmd/bump/main.go`
- Add "push" flag in "patch", "minor", and "major" commands to push tag to remote after creation in `cmd/bump/main.go`
- Refactor code to separate bumpVersion function from main function in `cmd/bump/main.go`
- Add error handling for failed tag creation and pushing in `cmd/bump/main.go`
- Update updateVersionFile function to update Version constant in file with new dev version in `cmd/bump/main.go`
- Add necessary git commands to stage and commit file after updating in `cmd/bump/main.go`
- Modify usage examples for bump command in README.md to include `--push` flag
- Add information about manually pushing tags if `--push` flag is not specified in README.md
- Add instructions for setting default push preference on per-repository basis in README.md
- Add import for `gopkg.in/ini.v1` package in `bump.go`
- Add CreateTag function to create new git tag with given tag in `bump.go`
- Add PushTag function to push latest git tag to remote repository in `bump.go`
- Add GetDefaultPushPreference function to read `[bump] defaultPush` value from `.git/config` in given repo path in `bump.go`
- Add SetDefaultPushPreference function to write `[bump] defaultPush` value to `.git/config` in given repo path in `bump.go`

[bump_test.go]
- Modify the test case `TestCreateTag` to check for an error with an invalid tag command.
- Add a new test case `TestCreateTagInvalid` to check for an error with an invalid tag.
[go.sum]
- Added version `v1.67.0` of `gopkg.in/ini.v1`
- Modified file `go.sum`
[go.mod]
- Add a new requirement for `gopkg.in/ini.v1 v1.67.0` in the `go.mod` file
[cmd/bump/main.go]
- Added a new command "push" to push tags to remote
- Added a new command "config" to configure bump settings for the repo
- In the "patch", "minor", and "major" commands, added a new flag "push" to push the tag to remote after creating it
- In the "patch", "minor", and "major" commands, added logic to check the repo default for pushing tags if the flag is not set on the CLI
- Refactored the code to separate the bumpVersion function from the main function
- Added error handling for failed tag creation and pushing
- Updated the updateVersionFile function to update the Version constant in a file with the new dev version
- Added the necessary git commands to stage and commit the file after updating
[README.md]
- Modified the usage examples for the bump command to include the `--push` flag
- Added information about manually pushing tags if `--push` flag is not specified
- Added instructions for setting the default push preference on a per-repository basis
[bump.go]
- Added import for the `gopkg.in/ini.v1` package
- Added a new function `CreateTag` to create a new git tag with the given tag
- Added a new function `PushTag` to push the latest git tag to the remote repository
- Added a new function `GetDefaultPushPreference` to read the `[bump] defaultPush` value from `.git/config` in the given repo path
- Added a new function `SetDefaultPushPreference` to write the `[bump] defaultPush` value to `.git/config` in the given repo path
