### PR TITLE
chore: Update .goreleaser.yaml to version 2 and adjust formatting

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
 
 before:
   hooks:
@@ -18,11 +18,11 @@ builds:
       - windows
       - darwin
     goarm:
-      - 6
-      - 7
+      - "6"
+      - "7"
     ignore:
-      - goos: darwin
-        goarch: 386
+      - goos: "darwin"
+        goarch: "386"
     main: ./cmd/bump
     binary: bump
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,8 @@ builds:
     binary: bump
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -39,7 +40,8 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 changelog:
   sort: asc


### PR DESCRIPTION
linting errors

- Incremented version from 1 to 2 in .goreleaser.yaml
- Changed goarm values to strings for consistency
- Updated darwin goos and goarch values to strings for consistency
